### PR TITLE
Commit Transaction entries in parallel

### DIFF
--- a/symstore/symstore.py
+++ b/symstore/symstore.py
@@ -254,8 +254,7 @@ class Transaction:
         # publish all entries files to the store in parallel if more than one
         if len(self.entries) > 1:
             executor = concurrent.futures.ThreadPoolExecutor()
-            futures = [executor.submit(TransactionEntry.publish, entry) for entry in self.entries]
-            concurrent.futures.wait(futures)
+            executor.map(TransactionEntry.publish, self.entries)
         else:
             for entry in self.entries:
                 entry.publish()


### PR DESCRIPTION
Use a ThreadPoolExecutor to commit transaction entries in parallel if more than one to be committed.

Fixes issue #24 

On my test VM, the time to compress and commit the first 8 DLLs in Qt 5.15 reduces from approx. 4 seconds to less than 1 second.

Note that this only improves performance when there are multiple PDBs or PEs in the same transaction. 